### PR TITLE
Fix the saring counter error #3 & bug in iOS 18.1 Safari #6

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,7 +7,7 @@
 
 /* TODO: potentially pushing HTML elements out of viewport, had to get rid of the class for Teroka and Sumber */
 .App-main {
-  height: 100%;
+/*   height: 100%; */
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/Lesen.css
+++ b/src/pages/Lesen.css
@@ -1,6 +1,8 @@
 #lesen {
-    width: 45%;
+/*     width: 45%; */
     border: 1px solid #aaa;
     border-radius: 20px;
     padding: 20px;
+    margin: 20px;
+    max-width: 720px;
 }

--- a/src/pages/TerokaTema.js
+++ b/src/pages/TerokaTema.js
@@ -19,8 +19,6 @@ function TerokaTema() {
   const [pantun, setPantun] = useState("");
   const [loading, setLoading] = useState(true);
 
-  let filteredPantunList = []; // Contains the list of pantun to be rendered
-
   useEffect(() => {
     handleSubmit();
     // NOTE: the line below is for my annoying linter (I don't like warnings)
@@ -92,7 +90,7 @@ function TerokaTema() {
   }
 
   // Call pantun filtering function before render
-  filteredPantunList = getFilteredPantunList();
+  const pantunListToRender = getFilteredPantunList();
 
   return (
     <main className="d-flex flex-column justify-content-between align-items-center my-3">
@@ -112,11 +110,11 @@ function TerokaTema() {
       </section>
       {saringKeyword.length > 0 ? (
         <span className="text-muted" style={{ fontSize: "smaller" }}>
-          Kami jumpa {filteredPantunList.length} pantun untuk tema: {nama_tema}.
+          Kami jumpa {pantunListToRender.length} pantun untuk tema: {nama_tema}.
         </span>
       ) : (
         <span className="text-muted" style={{ fontSize: "smaller" }}>
-          Kami jumpa {filteredPantunList.length} pantun untuk tema: {nama_tema}.
+          Kami jumpa {pantunListToRender.length} pantun untuk tema: {nama_tema}.
         </span>
       )}
       <span className="text-muted mb-3" style={{ fontSize: "smaller" }}>
@@ -124,7 +122,7 @@ function TerokaTema() {
       </span>
    
       <div className="pantun-pantun">
-        {filteredPantunList.map((p, index) => {
+        {pantunListToRender.map((p, index) => {
             return <Pantun kata={saringKeyword} key={index}>{p}</Pantun>;
           })
         }

--- a/src/pages/TerokaTema.js
+++ b/src/pages/TerokaTema.js
@@ -63,24 +63,25 @@ function TerokaTema() {
   };
 
   const getFilteredPantunList = () => {
-    // Return list of pantun for rendering
+    // Process and return list of pantun for rendering
+
     if (pantun.length > 0) {
       
       if (saringKeyword.length > 0) {
-        // Only perform filtering if saring "keyword" available
-        return pantun.filter((pantun, index, array) => {
+        // Only perform filtering when saring "keyword" available
+        return pantun.filter((p, index, array) => {
           const filterCheck =
-            pantun.pantun_bayang1.toLowerCase().includes(saringKeyword) ||
-            pantun.pantun_bayang2.toLowerCase().includes(saringKeyword) ||
-            pantun.pantun_maksud1.toLowerCase().includes(saringKeyword) ||
-            pantun.pantun_maksud2.toLowerCase().includes(saringKeyword);
+            p.pantun_bayang1.toLowerCase().includes(saringKeyword) ||
+            p.pantun_bayang2.toLowerCase().includes(saringKeyword) ||
+            p.pantun_maksud1.toLowerCase().includes(saringKeyword) ||
+            p.pantun_maksud2.toLowerCase().includes(saringKeyword);
           
           return filterCheck;
           } 
         );
 
       } else {
-        // Return all pantun since saring "word" unavailable
+        // Return all pantun since saring "keyword" unavailable
         return pantun;
       }
       
@@ -123,8 +124,8 @@ function TerokaTema() {
       </span>
    
       <div className="pantun-pantun">
-        {filteredPantunList.map((pantun, index) => {
-            return <Pantun kata={saringKeyword} key={index}>{pantun}</Pantun>;
+        {filteredPantunList.map((p, index) => {
+            return <Pantun kata={saringKeyword} key={index}>{p}</Pantun>;
           })
         }
       </div>

--- a/src/pages/TerokaTema.js
+++ b/src/pages/TerokaTema.js
@@ -15,9 +15,11 @@ let headers = {
 
 function TerokaTema() {
   const { tema_id, nama_tema } = useLocation().state;
-  const [filteredPantun, setFilteredPantun] = useState("");
+  const [saringKeyword, setSaringKeyword] = useState("");
   const [pantun, setPantun] = useState("");
   const [loading, setLoading] = useState(true);
+
+  let filteredPantunList = []; // Contains the list of pantun to be rendered
 
   useEffect(() => {
     handleSubmit();
@@ -57,8 +59,39 @@ function TerokaTema() {
     );
 
   const handleChange = (e) => {
-    setFilteredPantun(e.target.value);
+    setSaringKeyword(e.target.value);
   };
+
+  const getFilteredPantunList = () => {
+    // Return list of pantun for rendering
+    if (pantun.length > 0) {
+      
+      if (saringKeyword.length > 0) {
+        // Only perform filtering if saring "keyword" available
+        return pantun.filter((pantun, index, array) => {
+          const filterCheck =
+            pantun.pantun_bayang1.toLowerCase().includes(saringKeyword) ||
+            pantun.pantun_bayang2.toLowerCase().includes(saringKeyword) ||
+            pantun.pantun_maksud1.toLowerCase().includes(saringKeyword) ||
+            pantun.pantun_maksud2.toLowerCase().includes(saringKeyword);
+          
+          return filterCheck;
+          } 
+        );
+
+      } else {
+        // Return all pantun since saring "word" unavailable
+        return pantun;
+      }
+      
+    } else {
+      // Return empty array since no pantun exist
+      return [];
+    }
+  }
+
+  // Call pantun filtering function before render
+  filteredPantunList = getFilteredPantunList();
 
   return (
     <main className="d-flex flex-column justify-content-between align-items-center my-3">
@@ -76,33 +109,24 @@ function TerokaTema() {
           Saring pantun guna perkataan.
         </div>
       </section>
-      {filteredPantun.length > 0 ? (
+      {saringKeyword.length > 0 ? (
         <span className="text-muted" style={{ fontSize: "smaller" }}>
-          Kami jumpa {filteredPantun.length} pantun untuk tema: {nama_tema}.
+          Kami jumpa {filteredPantunList.length} pantun untuk tema: {nama_tema}.
         </span>
       ) : (
         <span className="text-muted" style={{ fontSize: "smaller" }}>
-          Kami jumpa {pantun.length} pantun untuk tema: {nama_tema}.
+          Kami jumpa {filteredPantunList.length} pantun untuk tema: {nama_tema}.
         </span>
       )}
       <span className="text-muted mb-3" style={{ fontSize: "smaller" }}>
         Tekan ikon untuk ketahui info lebih.
       </span>
+   
       <div className="pantun-pantun">
-        {pantun.length > 0
-          ? pantun.map((p) => {
-              const filterCheck =
-                p.pantun_bayang1.toLowerCase().includes(filteredPantun) ||
-                p.pantun_bayang2.toLowerCase().includes(filteredPantun) ||
-                p.pantun_maksud1.toLowerCase().includes(filteredPantun) ||
-                p.pantun_maksud2.toLowerCase().includes(filteredPantun);
-              if (filterCheck) {
-                return <Pantun kata={""}>{p}</Pantun>;
-              } else {
-                return <></>;
-              }
-            })
-          : ""}
+        {filteredPantunList.map((pantun, index) => {
+            return <Pantun kata={saringKeyword} key={index}>{pantun}</Pantun>;
+          })
+        }
       </div>
     </main>
   );


### PR DESCRIPTION
### Primary Changes
- Change `filteredPantun` to `saringKeyword` as it reflect the user input text / keyword.
- Create `getFilteredPantunList()` function to process the pantun list received from server API.
  - If no pantun received from the server, this function return empty array.
  - If user does not provide any saring "keyword", this function return the pantun list without filtering.
  - If saring "keyword" exist, this function will do filtering before return the filtered list.
- Change `pantun.length` to `pantunListToRender.length` to make code consistent as it provide the same result.

### Notes
- The conditional rendering for `Kami jumpa {pantunListToRender.length} pantun untuk tema: {nama_tema}.` text is kept to allow for future update. We can put the saring "keyword" on the text as the feedback to user input (current feedback only show counter). Else, the conditional rendering can be removed.

### Additional Changes:
- Add `key={index}` props during pantun rendering to avoid React warning:
![11](https://github.com/user-attachments/assets/9ad8ccf6-eabe-4a4c-bb46-5ad6a67a0320)

